### PR TITLE
Fix missing expired column in DB schema

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -3,5 +3,6 @@
     username TEXT NOT NULL UNIQUE,
     password TEXT NOT NULL,
     mfa_secret TEXT NOT NULL,
-    gendate TIMESTAMP NOT NULL
+    gendate TIMESTAMP NOT NULL,
+    expired BOOLEAN NOT NULL DEFAULT FALSE
 );

--- a/postgres-deployment.yaml
+++ b/postgres-deployment.yaml
@@ -10,7 +10,8 @@ data:
         username TEXT NOT NULL UNIQUE,
         password TEXT NOT NULL,
         mfa_secret TEXT NOT NULL,
-        gendate TIMESTAMP NOT NULL
+        gendate TIMESTAMP NOT NULL,
+        expired BOOLEAN NOT NULL DEFAULT FALSE
     );
 ---
 apiVersion: v1

--- a/postgres-init.yaml
+++ b/postgres-init.yaml
@@ -10,5 +10,6 @@ data:
         username TEXT NOT NULL UNIQUE,
         password TEXT NOT NULL,
         mfa_secret TEXT NOT NULL,
-        gendate TIMESTAMP NOT NULL
+        gendate TIMESTAMP NOT NULL,
+        expired BOOLEAN NOT NULL DEFAULT FALSE
     );


### PR DESCRIPTION
## Summary
- add `expired` column to SQL initialization scripts

## Testing
- `python -m py_compile functions/authenticate-user/handler.py functions/create-user/handler.py functions/renew-user/handler.py`


------
https://chatgpt.com/codex/tasks/task_e_683f637e26708323b917fc1fccca4631