### PR TITLE
Ajout d'un script de démarrage automatisé

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ce projet est une preuve de concept (PoC) de gestion de comptes utilisateurs sé
 - 🔐 Mot de passe fort généré automatiquement
 - 📲 Double authentification (2FA) avec TOTP
 - ⏳ Expiration automatique au bout de 6 mois
-- 🐳 Déploiement complet via Docker Compose
+ - 🐳 Déploiement automatisé via script
 - 🌐 Frontend simple en HTML/JS + Bootstrap
 - ⚙️ Backend Serverless avec OpenFaaS + Python
 
@@ -17,14 +17,15 @@ Ce projet est une preuve de concept (PoC) de gestion de comptes utilisateurs sé
 
 ## ▶️ Démarrage rapide
 
+
 ```bash
 git clone <repo>
 cd projet
-docker compose up -d
+./start.sh
 ```
 
 - Frontend : http://localhost:8081  
-- OpenFaaS Gateway : http://localhost:8080 (admin/admin)
+- OpenFaaS Gateway : http://localhost:8080 (admin/\<mot-de-passe généré\>)
 
 ## 🧪 Tester
 
@@ -38,7 +39,7 @@ docker compose up -d
 
 - `frontend/` : index.html, script.js
 - `functions/` : create-user, authenticate-user, renew-user
-- `docker-compose.yml` : tous les services (PostgreSQL, OpenFaaS, frontend)
+- `docker-compose.yml` : conteneur du frontend
 - `init_cof_userdb.sql` : script de création de la table `users`
 
 ## 🛠️ Technologies

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+# Check prerequisites
+for cmd in docker kubectl helm faas-cli; do
+    if ! command -v $cmd >/dev/null 2>&1; then
+        echo "Error: $cmd is required but not installed." >&2
+        exit 1
+    fi
+done
+
+# Install OpenFaaS if not already installed
+if ! kubectl get namespace openfaas >/dev/null 2>&1; then
+    echo "Installing OpenFaaS via helm..."
+    helm repo add openfaas https://openfaas.github.io/faas-netes/
+    kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+    PASSWORD=$(head -c 12 /dev/urandom | shasum | cut -d' ' -f1)
+    kubectl -n openfaas create secret generic basic-auth \
+      --from-literal=basic-auth-user=admin \
+      --from-literal=basic-auth-password="$PASSWORD"
+    helm upgrade --install openfaas openfaas/openfaas \
+      --namespace openfaas \
+      --set basic_auth=true \
+      --set functionNamespace=openfaas-fn \
+      --set serviceType=NodePort \
+      --wait
+else
+    PASSWORD=$(kubectl -n openfaas get secret basic-auth -o jsonpath='{.data.basic-auth-password}' | base64 --decode)
+    echo "OpenFaaS already installed."
+fi
+
+# Port-forward gateway
+kubectl -n openfaas port-forward svc/gateway 8080:8080 &
+PF_PID=$!
+sleep 5
+
+# Deploy Postgres
+kubectl apply -f postgres-init.yaml
+kubectl apply -f postgres-deployment.yaml
+
+# Wait for Postgres
+kubectl -n openfaas wait --for=condition=ready pod -l app=postgres --timeout=180s
+
+# Deploy functions
+for stack in functions/*/stack.yml; do
+    faas-cli deploy -f "$stack"
+done
+
+# Update frontend password
+sed -i "s/const faasPassword = \".*\";/const faasPassword = \"$PASSWORD\";/" frontend/script.js
+
+# Start frontend container
+docker compose up -d
+
+printf '\nFrontend available at http://localhost:8081\n'
+printf 'OpenFaaS gateway at http://localhost:8080 (admin/%s)\n' "$PASSWORD"
+printf 'Press Ctrl+C to stop port-forwarding when finished.\n'
+wait $PF_PID


### PR DESCRIPTION
## Summary
- add `start.sh` to deploy OpenFaaS, Postgres and the frontend
- update README with new startup instructions and clarify compose usage

## Testing
- `shellcheck start.sh`

------
https://chatgpt.com/codex/tasks/task_e_684146e126488323be731e38c68fa003