### PR TITLE
Fix OpenFaaS handler signature

### DIFF
--- a/build/authenticate-user/function/handler.py
+++ b/build/authenticate-user/function/handler.py
@@ -20,9 +20,12 @@ def options():
     return make_response("", 204)
 
 @app.route("/", methods=["POST"])
-def handle():
+def main_route():
+    return handle(request.get_data(as_text=True))
+
+def handle(req):
     try:
-        data = request.get_json()
+        data = json.loads(req)
         username = data.get("username")
         password = data.get("password")
         code2fa = data.get("code2fa")

--- a/functions/authenticate-user/handler.py
+++ b/functions/authenticate-user/handler.py
@@ -20,9 +20,12 @@ def options():
     return make_response("", 204)
 
 @app.route("/", methods=["POST"])
-def handle():
+def main_route():
+    return handle(request.get_data(as_text=True))
+
+def handle(req):
     try:
-        data = request.get_json()
+        data = json.loads(req)
         username = data.get("username")
         password = data.get("password")
         code2fa = data.get("code2fa")


### PR DESCRIPTION
## Summary
- ensure authenticate-user handler accepts request data

## Testing
- `pytest -q`
- `pytest functions/authenticate-user -q`
- `pytest template/python3-flask/function/handler_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684159ea090c83238281723dba8eadef